### PR TITLE
mcobbett copyright tool embeds build date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,10 @@ source-code : \
 	./pkg/checkTypes \
 	./pkg/fileCheckers \
 	./pkg/embedded \
-	./pkg/embedded/resources/build-date.txt \
-	./pkg/embedded/resources/git-commit-sha.txt
-
+	./pkg/embedded/resources/build-date.txt 
+	
 ./pkg/embedded/resources/build-date.txt :
 	echo -n "Build date: $(date)" > ./pkg/embedded/resources/build-date.txt
-
-./pkg/embedded/resources/git-commit-sha.txt :
-	git commit | head -1 | xrgs > ./pkg/embedded/resources/git-commit-sha.txt
 
 bin/copyright : source-code
 	CGO_ENABLED=0 go build -o bin/copyright ./cmd/githubapp-copyright

--- a/cmd/githubapp-copyright/main.go
+++ b/cmd/githubapp-copyright/main.go
@@ -73,5 +73,4 @@ func logBuildInfo() {
 	log.Printf("Version %s\n", embedded.GetVersion())
 	log.Printf("%s\n", embedded.GetCopyright())
 	log.Printf("Build date: %s\n", embedded.GetBuildDate())
-	log.Printf("Latest git sha: %s\n", embedded.GetLatestGitCommitSha())
 }

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -15,9 +15,6 @@ var versionText string
 //go:embed resources/build-date.txt
 var buildDate string
 
-//go:embed resources/git-commit-sha.txt
-var gitCommitSha string
-
 //go:embed resources/copyright.txt
 var copyrightText string
 
@@ -27,10 +24,6 @@ func GetVersion() string {
 
 func GetBuildDate() string {
 	return buildDate
-}
-
-func GetLatestGitCommitSha() string {
-	return gitCommitSha
 }
 
 func GetCopyright() string {


### PR DESCRIPTION
- force rebuild
- update version to 1.1
- force re-build
- more build info logged
- add build date to copyright tool
