### PR TITLE
mcobbett github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,16 +66,16 @@ jobs:
     - uses: clowdhaus/argo-cd-action/@main
       with:
         version: 2.6.7
-        command: actions
-        options: app actions run github-copyright restart --kind Deployment --resource-name githubappcopyright
+        command: app
+        options: actions run github-copyright restart --kind Deployment --resource-name githubappcopyright
       # Only on main branch builds
       if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
 
     - uses: clowdhaus/argo-cd-action/@main
       with:
         version: 2.6.7
-        command: actions
-        options: app wait github-copyright --resource apps:Deployment:githubappcopyright --health
+        command: app
+        options: wait github-copyright --resource apps:Deployment:githubappcopyright --health
       # Only on main branch builds
       if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
 


### PR DESCRIPTION
- readme updated to include docker run and curl commands
- docker image pulled from different registry.
- docker image pulled from different registry.
- docker image pulled from different registry.
- github actions push to galasa-dev
- pr build to wake up argocd
- build pipe is same file for pr and branch builds
- build pipe is same file for pr and branch builds
- kick argocd at end of runs on main build
