### PR TITLE
mcobbett github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
       with:
         version: 2.6.7
         command: app
-        options: actions run github-copyright restart --kind Deployment --resource-name githubappcopyright
+        options: actions run github-copyright restart --kind Deployment --resource-name githubappcopyright --auth-token ${{ secrets.ARGOCD_CLI_TOKEN }} --server argocd.galasa.dev
       # Only on main branch builds
       if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
 
@@ -75,7 +75,7 @@ jobs:
       with:
         version: 2.6.7
         command: app
-        options: wait github-copyright --resource apps:Deployment:githubappcopyright --health
+        options: wait github-copyright --resource apps:Deployment:githubappcopyright --health --auth-token ${{ secrets.ARGOCD_CLI_TOKEN }} --server argocd.galasa.dev
       # Only on main branch builds
       if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
 


### PR DESCRIPTION
- readme updated to include docker run and curl commands
- docker image pulled from different registry.
- docker image pulled from different registry.
- docker image pulled from different registry.
- github actions push to galasa-dev
- pr build to wake up argocd
- build pipe is same file for pr and branch builds
- build pipe is same file for pr and branch builds
- kick argocd at end of runs on main build
- main build needs auth token to talk to argocd
